### PR TITLE
Add API documentation and implement organizations BFF with UI

### DIFF
--- a/app/api/organization/route.ts
+++ b/app/api/organization/route.ts
@@ -1,0 +1,195 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  fetchCadenceApi,
+  getCadenceRedirectDetails,
+} from "@/lib/server/cadence-api";
+import { AUTH_COOKIE_NAMES } from "@/lib/server/auth-cookies";
+
+type OrganizationResponse = {
+  login: string;
+};
+
+function isOrganizationResponse(value: unknown): value is OrganizationResponse {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const maybeOrganization = value as Record<string, unknown>;
+  return typeof maybeOrganization.login === "string";
+}
+
+function getAccessToken(request: NextRequest): string | null {
+  return request.cookies.get(AUTH_COOKIE_NAMES.access)?.value ?? null;
+}
+
+function createRedirectErrorResponse(
+  request: NextRequest,
+  response: Response,
+  reason: string,
+) {
+  const redirectDetails = getCadenceRedirectDetails(request, response);
+
+  return NextResponse.json(
+    {
+      reason,
+      code: redirectDetails.reauthUrl ? "reauth_required" : "upstream_redirect",
+      reauthUrl: redirectDetails.reauthUrl,
+      upstreamLocation: redirectDetails.upstreamLocation,
+      redirectStatus: redirectDetails.status,
+    },
+    { status: 409 },
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const accessToken = getAccessToken(request);
+
+  if (!accessToken) {
+    return NextResponse.json({ reason: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const response = await fetchCadenceApi("/v1/organization", {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: "application/json",
+      },
+      redirect: "manual",
+    });
+
+    if (response.status >= 300 && response.status < 400) {
+      return createRedirectErrorResponse(
+        request,
+        response,
+        "Reauthentication required",
+      );
+    }
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        return NextResponse.json({ login: null });
+      }
+
+      let backendError = "<failed to read backend error>";
+      try {
+        backendError = await response.text();
+      } catch (error) {
+        console.error("Failed reading organization error body", error);
+      }
+
+      console.error("BFF organization request failed", {
+        status: response.status,
+        backendError,
+      });
+
+      return NextResponse.json(
+        { reason: "Failed to fetch organization" },
+        { status: response.status },
+      );
+    }
+
+    const payload = (await response.json()) as unknown;
+    if (!isOrganizationResponse(payload)) {
+      console.error("Organization payload has invalid shape", payload);
+      return NextResponse.json(
+        { reason: "Failed to fetch organization" },
+        { status: 502 },
+      );
+    }
+
+    return NextResponse.json({ login: payload.login });
+  } catch (error) {
+    console.error("BFF organization request crashed", error);
+    return NextResponse.json(
+      { reason: "Failed to fetch organization" },
+      { status: 502 },
+    );
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  const accessToken = getAccessToken(request);
+
+  if (!accessToken) {
+    return NextResponse.json({ reason: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ reason: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (typeof body !== "object" || body === null) {
+    return NextResponse.json({ reason: "Invalid login" }, { status: 400 });
+  }
+
+  const maybeBody = body as Record<string, unknown>;
+  if (
+    typeof maybeBody.login !== "string" ||
+    maybeBody.login.trim().length === 0
+  ) {
+    return NextResponse.json({ reason: "Invalid login" }, { status: 400 });
+  }
+
+  const login = maybeBody.login.trim();
+
+  try {
+    const response = await fetchCadenceApi("/v1/organization", {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ login }),
+      redirect: "manual",
+    });
+
+    if (response.status >= 300 && response.status < 400) {
+      return createRedirectErrorResponse(
+        request,
+        response,
+        "Reauthentication required",
+      );
+    }
+
+    if (!response.ok) {
+      let backendError = "<failed to read backend error>";
+      try {
+        backendError = await response.text();
+      } catch (error) {
+        console.error("Failed reading organization update error body", error);
+      }
+
+      console.error("BFF organization update failed", {
+        status: response.status,
+        backendError,
+      });
+
+      return NextResponse.json(
+        { reason: "Failed to update organization" },
+        { status: response.status },
+      );
+    }
+
+    const payload = (await response.json()) as unknown;
+    if (!isOrganizationResponse(payload)) {
+      console.error("Organization update payload has invalid shape", payload);
+      return NextResponse.json(
+        { reason: "Failed to update organization" },
+        { status: 502 },
+      );
+    }
+
+    return NextResponse.json({ login: payload.login });
+  } catch (error) {
+    console.error("BFF organization update crashed", error);
+    return NextResponse.json(
+      { reason: "Failed to update organization" },
+      { status: 502 },
+    );
+  }
+}

--- a/app/api/organizations/route.ts
+++ b/app/api/organizations/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  fetchCadenceApi,
+  getCadenceRedirectDetails,
+} from "@/lib/server/cadence-api";
+import { AUTH_COOKIE_NAMES } from "@/lib/server/auth-cookies";
+
+type Organization = {
+  login: string;
+};
+
+function isOrganization(value: unknown): value is Organization {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const maybeOrganization = value as Record<string, unknown>;
+  return typeof maybeOrganization.login === "string";
+}
+
+export async function GET(request: NextRequest) {
+  const accessToken = request.cookies.get(AUTH_COOKIE_NAMES.access)?.value;
+
+  if (!accessToken) {
+    return NextResponse.json({ reason: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const response = await fetchCadenceApi("/v1/available-organizations", {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: "application/json",
+      },
+      redirect: "manual",
+    });
+
+    if (response.status >= 300 && response.status < 400) {
+      const redirectDetails = getCadenceRedirectDetails(request, response);
+
+      return NextResponse.json(
+        {
+          reason: "Reauthentication required",
+          code: redirectDetails.reauthUrl ? "reauth_required" : "upstream_redirect",
+          reauthUrl: redirectDetails.reauthUrl,
+          upstreamLocation: redirectDetails.upstreamLocation,
+          redirectStatus: redirectDetails.status,
+        },
+        { status: 409 },
+      );
+    }
+
+    if (!response.ok) {
+      let backendError = "<failed to read backend error>";
+      try {
+        backendError = await response.text();
+      } catch (error) {
+        console.error("Failed reading organizations error body", error);
+      }
+
+      console.error("BFF organizations request failed", {
+        status: response.status,
+        backendError,
+      });
+
+      return NextResponse.json(
+        { reason: "Failed to fetch organizations" },
+        { status: response.status },
+      );
+    }
+
+    const payload = (await response.json()) as unknown;
+    const organizations = Array.isArray(payload)
+      ? payload
+          .filter(isOrganization)
+          .map((organization) => ({
+            login: organization.login,
+          }))
+      : [];
+
+    return NextResponse.json({ organizations });
+  } catch (error) {
+    console.error("BFF organizations request crashed", error);
+    return NextResponse.json(
+      { reason: "Failed to fetch organizations" },
+      { status: 502 },
+    );
+  }
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { Suspense, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { logoutCurrentSession } from "@/lib/api/auth-client";
@@ -43,6 +44,14 @@ function DashboardContent() {
           >
             {isSigningOut ? "Signing out..." : "Sign out"}
           </button>
+        </div>
+        <div className="mb-8">
+          <Link
+            href="/setup"
+            className="inline-flex rounded-lg bg-[#FF2D55] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[#E60045]"
+          >
+            Setup
+          </Link>
         </div>
 
         <div className="grid gap-6 md:grid-cols-3">

--- a/app/setup/page.tsx
+++ b/app/setup/page.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  fetchOrganizations,
+  fetchSelectedOrganizationLogin,
+  isReauthRequiredError,
+  isUnauthorizedError,
+  updateSelectedOrganization,
+} from "@/lib/api/organizations-client";
+
+const GITHUB_APP_INSTALL_URL =
+  "https://github.com/apps/cadence-engineer/installations/new";
+
+export default function SetupPage() {
+  const router = useRouter();
+  const [organizations, setOrganizations] = useState<string[]>([]);
+  const [selectedOrganizationLogin, setSelectedOrganizationLogin] = useState<string | null>(
+    null,
+  );
+  const [isUpdatingSelection, setIsUpdatingSelection] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function loadOrganizations() {
+      setIsLoading(true);
+      setErrorMessage(null);
+
+      try {
+        const [availableOrganizations, selectedLogin] = await Promise.all([
+          fetchOrganizations(),
+          fetchSelectedOrganizationLogin(),
+        ]);
+        const availableOrganizationLogins = availableOrganizations.map(
+          (organization) => organization.login,
+        );
+
+        setOrganizations(availableOrganizationLogins);
+        setSelectedOrganizationLogin(
+          selectedLogin && availableOrganizationLogins.includes(selectedLogin)
+            ? selectedLogin
+            : null,
+        );
+      } catch (error) {
+        if (isUnauthorizedError(error)) {
+          router.replace("/sign-in");
+          return;
+        }
+
+        if (isReauthRequiredError(error)) {
+          router.replace(error.reauthUrl);
+          return;
+        }
+
+        console.error("Failed loading organizations", error);
+        setErrorMessage("Could not load organizations. Please try again.");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    void loadOrganizations();
+  }, [router]);
+
+  function handleSelectOrganization(login: string) {
+    if (isUpdatingSelection || selectedOrganizationLogin === login) {
+      return;
+    }
+
+    setSelectedOrganizationLogin(login);
+    setErrorMessage(null);
+  }
+
+  async function handleDone() {
+    if (!selectedOrganizationLogin || isUpdatingSelection) {
+      return;
+    }
+
+    setIsUpdatingSelection(true);
+    setErrorMessage(null);
+
+    try {
+      await updateSelectedOrganization(selectedOrganizationLogin);
+      router.push("/dashboard");
+    } catch (error) {
+      if (isUnauthorizedError(error)) {
+        router.replace("/sign-in");
+        return;
+      }
+
+      if (isReauthRequiredError(error)) {
+        router.replace(error.reauthUrl);
+        return;
+      }
+
+      console.error("Failed saving selected organization", error);
+      setErrorMessage("Could not save selected organization. Please try again.");
+    } finally {
+      setIsUpdatingSelection(false);
+    }
+  }
+
+  return (
+    <main className="h-full bg-transparent px-6 py-8 md:px-8 md:py-10">
+      <section className="mx-auto w-full max-w-4xl rounded-2xl bg-white p-8 shadow-[0_14px_40px_rgba(0,0,0,0.18)] md:p-10">
+        <h1 className="mb-2 text-3xl font-bold tracking-tight text-black">
+          Setup
+        </h1>
+        <p className="mb-6 text-black">
+          Connect your GitHub organization and choose where Cadence Engineer should run.
+        </p>
+
+        {isLoading ? (
+          <p className="text-sm text-black/80">
+            Loading organizations...
+          </p>
+        ) : null}
+
+        {errorMessage ? (
+          <p className="rounded-md bg-[#FFE8EE] px-3 py-2 text-sm text-[#8A1230]">
+            {errorMessage}
+          </p>
+        ) : null}
+
+        {!isLoading && !errorMessage && organizations.length === 0 ? (
+          <div className="rounded-xl bg-[#FFF4F7] p-6">
+            <p className="mb-4 text-sm text-black">
+              No linked organizations found yet.
+            </p>
+            <a
+              href={GITHUB_APP_INSTALL_URL}
+              className="inline-flex items-center justify-center rounded-lg bg-[#FF2D55] px-5 py-3 text-sm font-semibold text-white transition hover:bg-[#E60045]"
+            >
+              Add GitHub organization
+            </a>
+          </div>
+        ) : null}
+
+        {!isLoading && !errorMessage && organizations.length > 0 ? (
+          <div className="space-y-4">
+            <div className="space-y-3">
+              {organizations.map((organizationLogin) => {
+                const isSelected = selectedOrganizationLogin === organizationLogin;
+
+                return (
+                  <button
+                    key={organizationLogin}
+                    type="button"
+                    onClick={() => void handleSelectOrganization(organizationLogin)}
+                    disabled={isUpdatingSelection}
+                    className={`w-full rounded-xl border p-4 text-left transition ${
+                      isSelected
+                        ? "border-[#FF2D55] bg-[#FFF4F7]"
+                        : "border-black/10 bg-white hover:border-[#FF2D55]/60"
+                    }`}
+                  >
+                    <p className="text-base font-semibold text-black">
+                      {organizationLogin}
+                    </p>
+                  </button>
+                );
+              })}
+            </div>
+            <button
+              type="button"
+              onClick={() => void handleDone()}
+              disabled={!selectedOrganizationLogin || isUpdatingSelection}
+              className="flex w-full items-center justify-center rounded-lg bg-[#FF2D55] px-5 py-3 text-sm font-semibold text-white transition hover:bg-[#E60045] disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {isUpdatingSelection ? "Saving..." : "Done"}
+            </button>
+            <a
+              href={GITHUB_APP_INSTALL_URL}
+              className="flex w-full items-center justify-center rounded-lg border border-[#FF2D55] bg-transparent px-5 py-3 text-sm font-semibold text-[#FF2D55] transition hover:bg-[#FFF4F7]"
+            >
+              Add GitHub organization
+            </a>
+          </div>
+        ) : null}
+      </section>
+    </main>
+  );
+}

--- a/documentation/Endpoints.md
+++ b/documentation/Endpoints.md
@@ -1,0 +1,428 @@
+# Cadence Engineer API Endpoints
+
+Base path: `/v1`
+
+## Conventions
+
+- Content type for JSON endpoints: `application/json`
+- Authenticated endpoints use bearer tokens:
+  - `Authorization: Bearer <cadence_access_token>`
+- Error responses are produced by `CadenceEngineerErrorMiddleware` in this shape:
+
+```json
+{
+  "error": true,
+  "runId": "8CC5C9AA-2E73-4E11-B84A-7E457AD01F95",
+  "schemaVersion": "1.0.0",
+  "reason": "Human-readable error message"
+}
+```
+
+Notes:
+- `runId` is nullable and only present when a route creates a `Run` for the request.
+- Some endpoints return a status only (`200 OK`) with no JSON body.
+
+---
+
+## `GET /v1`
+
+### What it does
+Health/check endpoint. Returns a simple string.
+
+### What it needs
+- No auth
+- No request body
+
+### What it returns
+- `200 OK`
+- Plain text body: `It works!`
+
+### Example response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: text/plain; charset=utf-8
+
+It works!
+```
+
+---
+
+## `GET /v1/hello`
+
+### What it does
+Simple hello endpoint. Also creates a run context for the request.
+
+### What it needs
+- No auth
+- No request body
+
+### What it returns
+- `200 OK`
+- Plain text body: `Hello, world!`
+- Response header: `X-Run-Id: <uuid>`
+
+### Example response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: text/plain; charset=utf-8
+X-Run-Id: 8CC5C9AA-2E73-4E11-B84A-7E457AD01F95
+
+Hello, world!
+```
+
+---
+
+## `POST /v1/auth/github`
+
+### What it does
+Exchanges a GitHub OAuth `code`, resolves or creates the internal Cadence user, and returns a Cadence access token.
+
+### What it needs
+- No Cadence auth required (public endpoint)
+- JSON request body:
+  - `code` (string, required, non-empty)
+
+### Request example
+
+```json
+{
+  "code": "1a2b3c4d5e6f"
+}
+```
+
+### What it returns
+- `200 OK`
+- JSON response body:
+  - `accessToken` (string)
+
+### Response example
+
+```json
+{
+  "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+}
+```
+
+### Common error example
+
+```json
+{
+  "error": true,
+  "runId": null,
+  "schemaVersion": "1.0.0",
+  "reason": "Validation failed: code is required"
+}
+```
+
+---
+
+## `GET /v1/available-organizations`
+
+### What it does
+Returns only GitHub organizations for the authenticated Cadence user
+that have GitHub app installation `2996623`.
+
+### What it needs
+- Bearer auth with a Cadence JWT
+- The authenticated user must have a stored GitHub access token
+- No request body
+
+### Headers example
+
+```http
+Authorization: Bearer <cadence_access_token>
+```
+
+### What it returns
+- `200 OK`
+- JSON response body: array (filtered to orgs that have installation `2996623`)
+  - `login` (string)
+
+### Response example
+
+```json
+[
+  {
+    "login": "cadence-engineer"
+  }
+]
+```
+
+### Common error example (missing GitHub access token)
+
+```json
+{
+  "error": true,
+  "runId": null,
+  "schemaVersion": "1.0.0",
+  "reason": "Missing GitHub access token for the authenticated user."
+}
+```
+
+---
+
+## `GET /v1/organization`
+
+### What it does
+Returns the selected organization of the authenticated Cadence user.
+
+### What it needs
+- Bearer auth with a Cadence JWT
+- No request body
+
+### Headers example
+
+```http
+Authorization: Bearer <cadence_access_token>
+```
+
+### What it returns
+- `200 OK`
+- JSON response body:
+  - `login` (string)
+
+### Response example
+
+```json
+{
+  "login": "cadence-engineer"
+}
+```
+
+### Common error example
+
+```json
+{
+  "error": true,
+  "runId": null,
+  "schemaVersion": "1.0.0",
+  "reason": "No organization selected for the authenticated user."
+}
+```
+
+---
+
+## `PUT /v1/organization`
+
+### What it does
+Sets the selected organization for the authenticated Cadence user from a GitHub organization login.
+
+### What it needs
+- Bearer auth with a Cadence JWT
+- If the authenticated user has no stored GitHub access token,
+  the endpoint redirects to `/auth/github`
+- JSON request body:
+  - `login` (string, required, non-empty)
+
+### Headers example
+
+```http
+Authorization: Bearer <cadence_access_token>
+```
+
+### Request example
+
+```json
+{
+  "login": "cadence-engineer"
+}
+```
+
+### What it returns
+- `200 OK`
+- JSON response body:
+  - `login` (string)
+
+### Response example
+
+```json
+{
+  "login": "cadence-engineer"
+}
+```
+
+### Redirect example (missing GitHub access token)
+
+```http
+HTTP/1.1 307 Temporary Redirect
+Location: /auth/github
+```
+
+---
+
+## `POST /v1/pull-request-summaries`
+
+### What it does
+Fetches a GitHub pull request (including commits and changed files), resolves/stores summary artifacts, and returns success.
+
+### What it needs
+- No Cadence auth required
+- JSON request body:
+  - `owner` (string, required, non-empty)
+  - `repo` (string, required, non-empty)
+  - `pull_number` (int, required, `>= 1`)
+  - `token` (string, optional, GitHub token used for API calls)
+
+### Request example
+
+```json
+{
+  "owner": "octocat",
+  "repo": "hello-world",
+  "pull_number": 42,
+  "token": "github_pat_xxx"
+}
+```
+
+### What it returns
+- `200 OK`
+- No JSON response body (status only)
+- Response header: `X-Run-Id: <uuid>`
+
+### Response example
+
+```http
+HTTP/1.1 200 OK
+X-Run-Id: 8CC5C9AA-2E73-4E11-B84A-7E457AD01F95
+```
+
+### Common error example
+
+```json
+{
+  "error": true,
+  "runId": "8CC5C9AA-2E73-4E11-B84A-7E457AD01F95",
+  "schemaVersion": "1.0.0",
+  "reason": "Validation failed: pull_number is not valid"
+}
+```
+
+---
+
+## `POST /v1/daily-summaries`
+
+### What it does
+Generates or resolves a daily summary artifact for a given day.
+
+### What it needs
+- No Cadence auth required
+- JSON request body:
+  - `day` (string, required, format `YYYY-MM-DD`)
+
+### Request example
+
+```json
+{
+  "day": "2026-03-10"
+}
+```
+
+### What it returns
+- `200 OK`
+- No JSON response body (status only)
+- Response header: `X-Run-Id: <uuid>`
+
+### Response example
+
+```http
+HTTP/1.1 200 OK
+X-Run-Id: 8CC5C9AA-2E73-4E11-B84A-7E457AD01F95
+```
+
+### Common error example
+
+```json
+{
+  "error": true,
+  "runId": "8CC5C9AA-2E73-4E11-B84A-7E457AD01F95",
+  "schemaVersion": "1.0.0",
+  "reason": "Invalid day '2026/03/10'. Expected format: YYYY-MM-DD."
+}
+```
+
+---
+
+## `POST /v1/sprint-summaries`
+
+### What it does
+Generates or resolves a sprint summary artifact anchored to a given day.
+
+### What it needs
+- No Cadence auth required
+- JSON request body:
+  - `day` (string, required, format `YYYY-MM-DD`)
+
+### Request example
+
+```json
+{
+  "day": "2026-03-10"
+}
+```
+
+### What it returns
+- `200 OK`
+- No JSON response body (status only)
+- Response header: `X-Run-Id: <uuid>`
+
+### Response example
+
+```http
+HTTP/1.1 200 OK
+X-Run-Id: 8CC5C9AA-2E73-4E11-B84A-7E457AD01F95
+```
+
+### Common error example
+
+```json
+{
+  "error": true,
+  "runId": "8CC5C9AA-2E73-4E11-B84A-7E457AD01F95",
+  "schemaVersion": "1.0.0",
+  "reason": "Invalid day 'March 10, 2026'. Expected format: YYYY-MM-DD."
+}
+```
+
+---
+
+## `POST /v1/webhook/github`
+
+### What it does
+Receives GitHub app webhooks. It only acts on `installation` events and logs app install/uninstall actions.
+
+### What it needs
+- No Cadence auth required
+- Header:
+  - `X-GitHub-Event: installation` (required for processing)
+- JSON body for installation events:
+  - `action` (string enum: `created` or `deleted`)
+  - `installation.id` (int)
+
+### Request example
+
+```http
+X-GitHub-Event: installation
+Content-Type: application/json
+```
+
+```json
+{
+  "action": "created",
+  "installation": {
+    "id": 987654
+  }
+}
+```
+
+### What it returns
+- `200 OK`
+- No JSON response body
+- If `X-GitHub-Event` is not `installation`, the endpoint still returns `200 OK` and does nothing.
+
+### Response example
+
+```http
+HTTP/1.1 200 OK
+```

--- a/lib/api/organizations-client.ts
+++ b/lib/api/organizations-client.ts
@@ -1,0 +1,130 @@
+import { fetchBff } from "@/lib/api/client";
+
+export type Organization = {
+  login: string;
+};
+
+export class UnauthorizedError extends Error {
+  constructor() {
+    super("Unauthorized");
+    this.name = "UnauthorizedError";
+  }
+}
+
+export function isUnauthorizedError(error: unknown): error is UnauthorizedError {
+  return error instanceof UnauthorizedError;
+}
+
+export class ReauthRequiredError extends Error {
+  readonly reauthUrl: string;
+
+  constructor(reauthUrl: string) {
+    super("Reauthentication required");
+    this.name = "ReauthRequiredError";
+    this.reauthUrl = reauthUrl;
+  }
+}
+
+export function isReauthRequiredError(error: unknown): error is ReauthRequiredError {
+  return error instanceof ReauthRequiredError;
+}
+
+type RedirectErrorResponse = {
+  code?: string;
+  reauthUrl?: string;
+};
+
+async function throwIfReauthRequired(response: Response): Promise<void> {
+  if (response.status !== 409) {
+    return;
+  }
+
+  let payload: RedirectErrorResponse | null = null;
+
+  try {
+    payload = (await response.json()) as RedirectErrorResponse;
+  } catch {
+    return;
+  }
+
+  if (
+    payload?.code === "reauth_required" &&
+    typeof payload.reauthUrl === "string" &&
+    payload.reauthUrl.length > 0
+  ) {
+    throw new ReauthRequiredError(payload.reauthUrl);
+  }
+}
+
+type OrganizationsResponse = {
+  organizations: Organization[];
+};
+
+export async function fetchOrganizations(): Promise<Organization[]> {
+  const response = await fetchBff("/api/organizations", { method: "GET" });
+
+  if (response.status === 401) {
+    throw new UnauthorizedError();
+  }
+
+  await throwIfReauthRequired(response);
+
+  if (!response.ok) {
+    throw new Error(`Organizations request failed with status ${response.status}`);
+  }
+
+  const payload = (await response.json()) as OrganizationsResponse;
+  return Array.isArray(payload.organizations) ? payload.organizations : [];
+}
+
+type SelectedOrganizationResponse = {
+  login: string | null;
+};
+
+export async function fetchSelectedOrganizationLogin(): Promise<string | null> {
+  const response = await fetchBff("/api/organization", { method: "GET" });
+
+  if (response.status === 401) {
+    throw new UnauthorizedError();
+  }
+
+  await throwIfReauthRequired(response);
+
+  if (!response.ok) {
+    throw new Error(
+      `Selected organization request failed with status ${response.status}`,
+    );
+  }
+
+  const payload = (await response.json()) as SelectedOrganizationResponse;
+  return typeof payload.login === "string" ? payload.login : null;
+}
+
+export async function updateSelectedOrganization(login: string): Promise<string> {
+  const response = await fetchBff("/api/organization", {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ login }),
+  });
+
+  if (response.status === 401) {
+    throw new UnauthorizedError();
+  }
+
+  await throwIfReauthRequired(response);
+
+  if (!response.ok) {
+    throw new Error(
+      `Organization update request failed with status ${response.status}`,
+    );
+  }
+
+  const payload = (await response.json()) as SelectedOrganizationResponse;
+  if (typeof payload.login !== "string") {
+    throw new Error("Organization update returned invalid payload");
+  }
+
+  return payload.login;
+}

--- a/lib/server/cadence-api.ts
+++ b/lib/server/cadence-api.ts
@@ -1,3 +1,5 @@
+import type { NextRequest } from "next/server";
+
 function stripTrailingSlashes(value: string): string {
   return value.replace(/\/+$/, "");
 }
@@ -26,4 +28,42 @@ export async function fetchCadenceApi(
     ...init,
     cache: "no-store",
   });
+}
+
+type CadenceRedirectDetails = {
+  status: number;
+  upstreamLocation: string | null;
+  reauthUrl: string | null;
+};
+
+const CADENCE_GITHUB_AUTH_PATH = "/auth/github";
+const BFF_GITHUB_AUTH_START_PATH = "/auth/github/start";
+
+export function getCadenceRedirectDetails(
+  request: NextRequest,
+  response: Response,
+): CadenceRedirectDetails {
+  const upstreamLocation = response.headers.get("location");
+
+  let reauthUrl: string | null = null;
+
+  if (upstreamLocation) {
+    try {
+      const upstreamUrl = new URL(upstreamLocation, getCadenceApiBaseUrl());
+      if (upstreamUrl.pathname === CADENCE_GITHUB_AUTH_PATH) {
+        reauthUrl = new URL(BFF_GITHUB_AUTH_START_PATH, request.url).pathname;
+      }
+    } catch (error) {
+      console.error("Failed to parse upstream redirect location", {
+        upstreamLocation,
+        error,
+      });
+    }
+  }
+
+  return {
+    status: response.status,
+    upstreamLocation,
+    reauthUrl,
+  };
 }


### PR DESCRIPTION
This pull request introduces a new organization setup flow, allowing users to select and manage their GitHub organization within the app. It adds backend API routes for organization selection, a frontend setup page, and client utilities for organization operations, as well as error handling for authentication and reauthentication scenarios. The dashboard now links to the setup page, and supporting server utilities are included.

**Organization selection and setup flow:**

* Added new API routes `app/api/organization/route.ts` and `app/api/organizations/route.ts` for fetching and updating the selected organization, with robust error handling for authentication and reauthentication requirements. [[1]](diffhunk://#diff-5b341433f832709689700e03fc07c8af33ca034f56d347d4bc1b1086c7a1d4a2R1-R195) [[2]](diffhunk://#diff-76b32257c84609314a9f760c592867cd9cf8909acf320d050dc5cd0e7af19e60R1-R89)
* Implemented a new setup page in `app/setup/page.tsx` that allows users to select from available organizations or add a new one, handling loading, selection, saving, and authentication errors.
* Added client utility functions in `lib/api/organizations-client.ts` for fetching available organizations, fetching/updating the selected organization, and handling authentication/reauthentication errors.

**Dashboard integration:**

* Added a "Setup" link to the dashboard page (`app/dashboard/page.tsx`) for easy access to the new organization setup flow. [[1]](diffhunk://#diff-e16c1c1133d5d72341ada507f3e06fa37dd79de574403f158159ff934f9b5013R3) [[2]](diffhunk://#diff-e16c1c1133d5d72341ada507f3e06fa37dd79de574403f158159ff934f9b5013R48-R55)

**Server utility improvements:**

* Added `getCadenceRedirectDetails` to `lib/server/cadence-api.ts` to extract redirect and reauthentication details from upstream API responses, used by the new API routes for error handling. [[1]](diffhunk://#diff-aa7521cde14d994a8c6a0ad7a512a8e977148fe9204578b7ac5f294ba72daa5dR1-R2) [[2]](diffhunk://#diff-aa7521cde14d994a8c6a0ad7a512a8e977148fe9204578b7ac5f294ba72daa5dR32-R69)