### PR TITLE
Replace Sign out button with profile chip showing user name

### DIFF
--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -3,9 +3,53 @@ import Link from "next/link";
 import { cookies } from "next/headers";
 import { AUTH_COOKIE_NAMES } from "@/lib/server/auth-cookies";
 
+type JwtPayload = {
+  name?: unknown;
+  preferred_username?: unknown;
+  login?: unknown;
+  given_name?: unknown;
+};
+
+function decodeJwtPayload(token: string): JwtPayload | null {
+  const parts = token.split(".");
+  if (parts.length < 2) {
+    return null;
+  }
+
+  const payloadSegment = parts[1];
+  const normalized = payloadSegment.replace(/-/g, "+").replace(/_/g, "/");
+  const padLength = (4 - (normalized.length % 4)) % 4;
+  const padded = normalized.padEnd(normalized.length + padLength, "=");
+
+  try {
+    const json = Buffer.from(padded, "base64").toString("utf8");
+    return JSON.parse(json) as JwtPayload;
+  } catch {
+    return null;
+  }
+}
+
+function getDisplayName(accessToken: string): string {
+  const payload = decodeJwtPayload(accessToken);
+  const possibleName =
+    payload?.name ??
+    payload?.preferred_username ??
+    payload?.login ??
+    payload?.given_name;
+
+  if (typeof possibleName !== "string") {
+    return "Account";
+  }
+
+  const normalizedName = possibleName.trim();
+  return normalizedName.length > 0 ? normalizedName : "Account";
+}
+
 export async function Header() {
   const cookieStore = await cookies();
-  const isSignedIn = Boolean(cookieStore.get(AUTH_COOKIE_NAMES.access)?.value);
+  const accessToken = cookieStore.get(AUTH_COOKIE_NAMES.access)?.value;
+  const isSignedIn = Boolean(accessToken);
+  const displayName = accessToken ? getDisplayName(accessToken) : "";
 
   return (
     <header className="bg-transparent px-6 py-4 md:px-8">
@@ -24,14 +68,22 @@ export async function Header() {
           />
         </Link>
         {isSignedIn ? (
-          <form action="/auth/sign-out" method="post">
-            <button
-              type="submit"
-              className="text-sm font-semibold text-[#FF2D55] hover:text-[#E60045]"
-            >
-              Sign out
-            </button>
-          </form>
+          <div className="inline-flex items-center gap-2 rounded-full bg-white/80 px-3 py-2 shadow-sm">
+            <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-[#FF2D55]/10 text-[#FF2D55]">
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 24 24"
+                className="h-4 w-4"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <circle cx="12" cy="8" r="4" />
+                <path d="M5 20a7 7 0 0 1 14 0" />
+              </svg>
+            </span>
+            <span className="text-sm font-semibold text-black">{displayName}</span>
+          </div>
         ) : (
           <nav className="flex items-center gap-6 text-sm font-semibold">
             <Link href="/pricing" className="text-[#FF2D55] hover:text-[#E60045]">


### PR DESCRIPTION
### Motivation
- Improve the signed-in header UX by showing a compact profile indicator (icon + display name) instead of a standalone `Sign out` button to provide clearer identity context.
- Derive a readable name from the existing access token so no additional backend calls are needed for the header.
- Keep the signed-out navigation unchanged and avoid changing global auth flows.

### Description
- Replaced the form/button sign-out UI in `app/components/header.tsx` with a compact profile chip that shows an SVG avatar and the user display name. 
- Added a small JWT payload decoder (`decodeJwtPayload`) and a `getDisplayName` helper in `app/components/header.tsx` to extract `name`, `preferred_username`, `login`, or `given_name` from the access token with a safe fallback to `Account`.
- Updated signed-in detection to read the access token once and compute `displayName` for rendering without introducing external dependencies.

### Testing
- Ran `pnpm lint` and it completed successfully.
- Ran `pnpm build` (Next.js production build) and it completed successfully.
- Executed an automated Playwright script to load the app with a synthetic JWT cookie and capture a header screenshot, which completed successfully and produced an artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6d18df0b083309a397b298d6b5483)