### PR TITLE
Display authenticated user's name in header and update API docs

### DIFF
--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -1,55 +1,58 @@
 import Image from "next/image";
 import Link from "next/link";
 import { cookies } from "next/headers";
+import { fetchCadenceApi } from "@/lib/server/cadence-api";
 import { AUTH_COOKIE_NAMES } from "@/lib/server/auth-cookies";
 
-type JwtPayload = {
-  name?: unknown;
-  preferred_username?: unknown;
-  login?: unknown;
-  given_name?: unknown;
+type UserNameResponse = {
+  name: string;
 };
 
-function decodeJwtPayload(token: string): JwtPayload | null {
-  const parts = token.split(".");
-  if (parts.length < 2) {
-    return null;
+function isUserNameResponse(value: unknown): value is UserNameResponse {
+  if (typeof value !== "object" || value === null) {
+    return false;
   }
 
-  const payloadSegment = parts[1];
-  const normalized = payloadSegment.replace(/-/g, "+").replace(/_/g, "/");
-  const padLength = (4 - (normalized.length % 4)) % 4;
-  const padded = normalized.padEnd(normalized.length + padLength, "=");
-
-  try {
-    const json = Buffer.from(padded, "base64").toString("utf8");
-    return JSON.parse(json) as JwtPayload;
-  } catch {
-    return null;
-  }
+  const maybeUserName = value as Record<string, unknown>;
+  return typeof maybeUserName.name === "string";
 }
 
-function getDisplayName(accessToken: string): string {
-  const payload = decodeJwtPayload(accessToken);
-  const possibleName =
-    payload?.name ??
-    payload?.preferred_username ??
-    payload?.login ??
-    payload?.given_name;
+async function getDisplayName(accessToken: string): Promise<string> {
+  try {
+    const response = await fetchCadenceApi("/v1/user/name", {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: "application/json",
+      },
+    });
 
-  if (typeof possibleName !== "string") {
+    if (!response.ok) {
+      console.error("Failed to fetch user name for header", {
+        status: response.status,
+      });
+      return "Account";
+    }
+
+    const payload = (await response.json()) as unknown;
+    if (!isUserNameResponse(payload)) {
+      console.error("Invalid user name payload shape for header", payload);
+      return "Account";
+    }
+
+    const normalizedName = payload.name.trim();
+    return normalizedName.length > 0 ? normalizedName : "Account";
+  } catch (error) {
+    console.error("Failed to fetch user name for header", error);
     return "Account";
   }
-
-  const normalizedName = possibleName.trim();
-  return normalizedName.length > 0 ? normalizedName : "Account";
 }
 
 export async function Header() {
   const cookieStore = await cookies();
   const accessToken = cookieStore.get(AUTH_COOKIE_NAMES.access)?.value;
   const isSignedIn = Boolean(accessToken);
-  const displayName = accessToken ? getDisplayName(accessToken) : "";
+  const displayName = accessToken ? await getDisplayName(accessToken) : "";
 
   return (
     <header className="bg-transparent px-6 py-4 md:px-8">

--- a/documentation/Endpoints.md
+++ b/documentation/Endpoints.md
@@ -78,6 +78,10 @@ Hello, world!
 
 ### What it does
 Exchanges a GitHub OAuth `code`, resolves or creates the internal Cadence user, and returns a Cadence access token.
+The returned Cadence JWT includes the GitHub OAuth access token claim for downstream GitHub requests.
+Only allowlisted GitHub IDs can authenticate:
+- `47605786`
+- `265279238`
 
 ### What it needs
 - No Cadence auth required (public endpoint)
@@ -116,17 +120,26 @@ Exchanges a GitHub OAuth `code`, resolves or creates the internal Cadence user, 
 }
 ```
 
+### Common error example (GitHub account not allowlisted)
+
+```json
+{
+  "error": true,
+  "runId": null,
+  "schemaVersion": "1.0.0",
+  "reason": "GitHub account is not allowlisted."
+}
+```
+
 ---
 
-## `GET /v1/available-organizations`
+## `GET /v1/user`
 
 ### What it does
-Returns only GitHub organizations for the authenticated Cadence user
-that have GitHub app installation `2996623`.
+Returns the authenticated Cadence user profile.
 
 ### What it needs
 - Bearer auth with a Cadence JWT
-- The authenticated user must have a stored GitHub access token
 - No request body
 
 ### Headers example
@@ -137,7 +150,76 @@ Authorization: Bearer <cadence_access_token>
 
 ### What it returns
 - `200 OK`
-- JSON response body: array (filtered to orgs that have installation `2996623`)
+- JSON response body:
+  - `id` (UUID)
+  - `name` (string)
+  - `email` (string or null)
+  - `githubID` (integer or null)
+
+### Response example
+
+```json
+{
+  "id": "8cc5c9aa-2e73-4e11-b84a-7e457ad01f95",
+  "name": "Cadence User",
+  "email": "cadence@example.com",
+  "githubID": 47605786
+}
+```
+
+---
+
+## `GET /v1/user/name`
+
+### What it does
+Returns only the authenticated Cadence user's name.
+
+### What it needs
+- Bearer auth with a Cadence JWT
+- No request body
+
+### Headers example
+
+```http
+Authorization: Bearer <cadence_access_token>
+```
+
+### What it returns
+- `200 OK`
+- JSON response body:
+  - `name` (string)
+
+### Response example
+
+```json
+{
+  "name": "Cadence User"
+}
+```
+
+---
+
+## `GET /v1/available-organizations`
+
+### What it does
+Returns only GitHub organizations for the authenticated Cadence user
+where the Cadence GitHub app (`cadence-engineer`) is installed and visible
+to that user.
+
+### What it needs
+- Bearer auth with a Cadence JWT
+- The Cadence JWT must include a GitHub access token claim
+- No request body
+
+### Headers example
+
+```http
+Authorization: Bearer <cadence_access_token>
+```
+
+### What it returns
+- `200 OK`
+- JSON response body: array (filtered to orgs with installed app `cadence-engineer`)
   - `login` (string)
 
 ### Response example
@@ -150,7 +232,7 @@ Authorization: Bearer <cadence_access_token>
 ]
 ```
 
-### Common error example (missing GitHub access token)
+### Common error example (missing GitHub access token claim)
 
 ```json
 {
@@ -208,11 +290,14 @@ Authorization: Bearer <cadence_access_token>
 
 ### What it does
 Sets the selected organization for the authenticated Cadence user from a GitHub organization login.
+During this operation, the API also resolves the `cadence-engineer` app installation for that organization,
+creates a GitHub installation access token, and stores it on the organization installation record.
 
 ### What it needs
 - Bearer auth with a Cadence JWT
-- If the authenticated user has no stored GitHub access token,
+- If the Cadence JWT has no GitHub access token claim,
   the endpoint redirects to `/auth/github`
+- The selected organization must have the `cadence-engineer` GitHub app installed
 - JSON request body:
   - `login` (string, required, non-empty)
 
@@ -248,6 +333,28 @@ Authorization: Bearer <cadence_access_token>
 ```http
 HTTP/1.1 307 Temporary Redirect
 Location: /auth/github
+```
+
+### Validation error example (empty login)
+
+```json
+{
+  "error": true,
+  "runId": null,
+  "schemaVersion": "1.0.0",
+  "reason": "login is empty"
+}
+```
+
+### Common error example (app not installed)
+
+```json
+{
+  "error": true,
+  "runId": null,
+  "schemaVersion": "1.0.0",
+  "reason": "GitHub app 'cadence-engineer' is not installed for organization 'acme'."
+}
 ```
 
 ---


### PR DESCRIPTION
### Motivation
- The backend added authenticated user endpoints and the UI should display the actual logged-in user's name in the header instead of a static "Account" label.
- Documentation needed to reflect the new `/v1/user` and `/v1/user/name` endpoints and updated organization/auth behavior.

### Description
- Updated `app/components/header.tsx` to call the backend BFF via `fetchCadenceApi('/v1/user/name')` using the Cadence access token and render the returned `name` in the signed-in header.
- Added runtime validation for the response shape and a safe fallback to `"Account"` when the request fails or returns invalid data.
- Replaced the previous JWT-payload-only name extraction logic with server-side name lookup to ensure the displayed name comes from the canonical API.
- Updated `documentation/Endpoints.md` to document `GET /v1/user` and `GET /v1/user/name` and to clarify organization/auth notes and error examples.

### Testing
- Ran `pnpm lint` and it completed successfully.
- Ran `pnpm build` and the Next.js production build completed successfully.
- Started the app against a mocked local backend and executed a Playwright script to render the home page and capture a screenshot verifying the signed-in header shows the fetched user name.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b75c9425b08330a8f9cc107486bdbf)