### PR TITLE
Fix stale signed-in header when access token expires

### DIFF
--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -17,7 +17,12 @@ function isUserNameResponse(value: unknown): value is UserNameResponse {
   return typeof maybeUserName.name === "string";
 }
 
-async function getDisplayName(accessToken: string): Promise<string> {
+type HeaderSessionIdentity = {
+  isSignedIn: boolean;
+  displayName: string;
+};
+
+async function getSessionIdentity(accessToken: string): Promise<HeaderSessionIdentity> {
   try {
     const response = await fetchCadenceApi("/v1/user/name", {
       method: "GET",
@@ -27,32 +32,53 @@ async function getDisplayName(accessToken: string): Promise<string> {
       },
     });
 
+    if (response.status === 401 || response.status === 403) {
+      return {
+        isSignedIn: false,
+        displayName: "",
+      };
+    }
+
     if (!response.ok) {
       console.error("Failed to fetch user name for header", {
         status: response.status,
       });
-      return "Account";
+      return {
+        isSignedIn: true,
+        displayName: "Account",
+      };
     }
 
     const payload = (await response.json()) as unknown;
     if (!isUserNameResponse(payload)) {
       console.error("Invalid user name payload shape for header", payload);
-      return "Account";
+      return {
+        isSignedIn: true,
+        displayName: "Account",
+      };
     }
 
     const normalizedName = payload.name.trim();
-    return normalizedName.length > 0 ? normalizedName : "Account";
+    return {
+      isSignedIn: true,
+      displayName: normalizedName.length > 0 ? normalizedName : "Account",
+    };
   } catch (error) {
     console.error("Failed to fetch user name for header", error);
-    return "Account";
+    return {
+      isSignedIn: true,
+      displayName: "Account",
+    };
   }
 }
 
 export async function Header() {
   const cookieStore = await cookies();
   const accessToken = cookieStore.get(AUTH_COOKIE_NAMES.access)?.value;
-  const isSignedIn = Boolean(accessToken);
-  const displayName = accessToken ? await getDisplayName(accessToken) : "";
+  const sessionIdentity = accessToken
+    ? await getSessionIdentity(accessToken)
+    : { isSignedIn: false, displayName: "" };
+  const { isSignedIn, displayName } = sessionIdentity;
 
   return (
     <header className="bg-transparent px-6 py-4 md:px-8">


### PR DESCRIPTION
### Motivation
- The header was rendering the profile pill whenever an access-token cookie existed, causing a stale signed-in UI after the token expired and the user was redirected to the landing page.
- The intent is to derive the signed-in state from a validated backend response rather than just cookie presence so the header shows `Sign in` when the session is no longer valid.

### Description
- Update `app/components/header.tsx` to add a `HeaderSessionIdentity` type and a new `getSessionIdentity` function that calls `/v1/user/name` to validate the session and obtain a display name.
- Treat `401` and `403` responses from the user-name endpoint as signed-out by returning `isSignedIn: false` so the header renders the sign-in links instead of a profile pill.
- Preserve a safe fallback that returns `displayName: "Account"` and `isSignedIn: true` for non-auth errors or malformed payloads so UI remains stable on transient failures.
- Change `Header` to use the validated session identity (`isSignedIn` and `displayName`) instead of `Boolean(accessToken)`.

### Testing
- Ran `pnpm lint` and it completed successfully.
- Ran `pnpm build` (Next.js production build) and it compiled and generated pages successfully.
- Started the dev server with `pnpm dev` and used a Playwright script to capture a screenshot of the landing/header to verify the signed-out UI; the script ran and produced an artifact image successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b76835e3c48330b4b85f0eb6b4cfb5)