### PR TITLE
Pin pnpm via packageManager in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,6 @@
     "eslint-config-next": "16.1.6",
     "tailwindcss": "^4",
     "typescript": "^5"
-  }
+  },
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
 }


### PR DESCRIPTION
Add a packageManager entry to package.json to lock pnpm@10.33.0 with its sha512 integrity string. This ensures consistent pnpm versions across environments and more reproducible installs.