### PR TITLE
Use webpack for build and respect $PORT on start

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
-    "build:webpack": "next build --webpack",
-    "start": "next start",
+    "build": "next build --webpack",
+    "start": "next start -p $PORT",
     "lint": "eslint"
   },
   "dependencies": {


### PR DESCRIPTION
Consolidate the build command to always run `next build --webpack` (remove separate `build:webpack` script) and update the start script to pass the runtime port with `next start -p $PORT`. This ensures builds use webpack by default and the server binds to the environment-provided PORT in deployment environments.