### PR TITLE
Use Webpack for builds and respect runtime PORT on start

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
-    "build:webpack": "next build --webpack",
-    "start": "next start",
+    "build": "next build --webpack",
+    "start": "next start -p $PORT",
     "lint": "eslint"
   },
   "dependencies": {


### PR DESCRIPTION
This pull request makes a minor update to the `package.json` scripts to ensure that the Next.js build always uses webpack and that the start command can accept a custom port via the `$PORT` environment variable.

- Script updates in `package.json`:
  * The `build` script now always runs `next build --webpack`, removing the separate `build:webpack` script. (`package.json`, [package.jsonL7-R8](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L7-R8))
  * The `start` script now supports specifying a port with the `$PORT` environment variable. (`package.json`, [package.jsonL7-R8](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L7-R8))